### PR TITLE
Remove mention of Raspberry Pi Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the following documents: 
 
-- [**The Raspberry Pi Style Guide 2.0**](https://github.com/raspberrypilearning/style-guide/blob/master/style-guide.md): this guide should be used when producing written material for the Raspberry Pi Foundation/Raspberry Pi Trading, and may be supplemented by reference to the *New Oxford Style Manual*. 
+- [**The Raspberry Pi Style Guide 2.0**](https://github.com/raspberrypilearning/style-guide/blob/master/style-guide.md): this guide should be used when producing written material for the Raspberry Pi Foundation, and may be supplemented by reference to the *New Oxford Style Manual*. 
 - [**Style Guide for Raspberry Pi learning resources**](https://github.com/raspberrypilearning/style-guide/blob/master/style-guide-for-resources.md): this guide should be used when preparing learning resources, to ensure that document formatting remains consistent across resources.  
 
 These guides are, inevitably, not exhaustive, and may be added to over time. Please be sure to refer to the version of the guide in this repository, which is considered to be the definitive record, and not to any forked copy you may have. 


### PR DESCRIPTION
RPT is now named Raspberry Pi Limited, and they have their own style-guide at https://github.com/raspberrypi/style-guide